### PR TITLE
[WIP] HLL Rollup field mapper plugin implementation and Cardinality Agg hacking

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -697,7 +697,7 @@ class ClusterFormationTasks {
             // gradle task options are not processed until the end of the configuration phase
             if (node.config.debug) {
                 println 'Running elasticsearch in debug mode, suspending until connected on port 8000'
-                esJavaOpts.add('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000')
+                esJavaOpts.add('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000')
             }
             node.env['ES_JAVA_OPTS'] = esJavaOpts.join(" ")
 

--- a/plugins/mapper-hll/Makefile
+++ b/plugins/mapper-hll/Makefile
@@ -1,3 +1,6 @@
 test:
 	# run integration tests
 	gradle integTestRunner
+
+debug:
+	gradle :plugins:mapper-hll:integTest --debug-jvm

--- a/plugins/mapper-hll/Makefile
+++ b/plugins/mapper-hll/Makefile
@@ -1,0 +1,2 @@
+test:
+	gradle integTestRunner

--- a/plugins/mapper-hll/Makefile
+++ b/plugins/mapper-hll/Makefile
@@ -1,2 +1,3 @@
 test:
+	# run integration tests
 	gradle integTestRunner

--- a/plugins/mapper-hll/build.gradle
+++ b/plugins/mapper-hll/build.gradle
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+esplugin {
+  description 'The Mapper HLL plugin allows you to compute serialized HLLs at index-time and to store them in the index.'
+  classname 'org.elasticsearch.plugin.mapper.MapperHLLPlugin'
+}

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -208,6 +208,7 @@ public class HLLFieldMapper extends FieldMapper {
             byte[] hllBytes = baos.toByteArray();
             int hllBytesLength = hllBytes.length;
             assert hllBytesLength > 0 : "Encoded HLL had no bytes";
+            assert hllBytesLength == 7 : "Encoded HLL did not have 7 bytes";
             // FIXME: is it OK to use same BytesRef instance across two ops below?
             BytesRef hllBytesRef = new BytesRef(hllBytes);
 

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.hll;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.hash.MurmurHash3;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.fielddata.plain.BytesBinaryDVIndexFieldData;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.TypeParsers;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class HLLFieldMapper extends FieldMapper {
+
+    public static final String CONTENT_TYPE = "hll";
+
+    public static class Defaults {
+        public static final MappedFieldType FIELD_TYPE = new Murmur3FieldType();
+        static {
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    public static class Builder extends FieldMapper.Builder<Builder, HLLFieldMapper> {
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
+            builder = this;
+        }
+
+        @Override
+        public HLLFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new HLLFieldMapper(name, fieldType, defaultFieldType,
+                    context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+        }
+
+        @Override
+        protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
+            fieldType.setIndexOptions(IndexOptions.NONE);
+            defaultFieldType.setIndexOptions(IndexOptions.NONE);
+            fieldType.setHasDocValues(true);
+            defaultFieldType.setHasDocValues(true);
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node,
+                ParserContext parserContext) throws MapperParsingException {
+            Builder builder = new Builder(name);
+
+            // tweaking these settings is no longer allowed, the entire purpose of murmur3 fields is to store a hash
+            if (node.get("doc_values") != null) {
+                throw new MapperParsingException("Setting [doc_values] cannot be modified for field [" + name + "]");
+            }
+            if (node.get("index") != null) {
+                throw new MapperParsingException("Setting [index] cannot be modified for field [" + name + "]");
+            }
+
+            if (parserContext.indexVersionCreated().before(Version.V_5_0_0_alpha2)) {
+                node.remove("precision_step");
+            }
+
+            TypeParsers.parseField(builder, name, node, parserContext);
+
+            return builder;
+        }
+    }
+
+    // this only exists so a check can be done to match the field type to using murmur3 hashing...
+    public static class Murmur3FieldType extends MappedFieldType {
+        public Murmur3FieldType() {
+        }
+
+        protected Murmur3FieldType(Murmur3FieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public Murmur3FieldType clone() {
+            return new Murmur3FieldType(this);
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
+            failIfNoDocValues();
+            return new BytesBinaryDVIndexFieldData.Builder();
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            throw new QueryShardException(context, "HLL fields are not searchable: [" + name() + "]");
+        }
+    }
+
+    protected HLLFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+            Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields)
+            throws IOException {
+        final Object value;
+        // controlling the context is what allows us to access array and other values
+        if (context.externalValueSet()) {
+            value = context.externalValue();
+        } else {
+            // this is assuming that the murmur3 hash field value is just in there as text
+            value = context.parser().textOrNull();
+        }
+        if (value != null) {
+            // value is turned into bytes
+            final BytesRef bytes = new BytesRef(value.toString());
+            // those bytes are hashed
+            final long hash = MurmurHash3.hash128(bytes.bytes, bytes.offset, bytes.length, 0, new MurmurHash3.Hash128()).h1;
+
+            // OK, but how do we take multiple values and HLL them?
+            // do we need to use parse() rather than parseCreateField?
+            // See GeoPointFieldMapper for an implementation of parse() using START_ARRAY and similar
+            
+            // all the above is ignored and a hard-coded binary string is added to the index
+            fields.add(new BinaryDocValuesField(fieldType().name(), new BytesRef("xxx")));
+            if (fieldType().stored()) {
+                fields.add(new StoredField(name(), hash));
+            }
+        }
+    }
+
+}

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -172,8 +172,9 @@ public class HLLFieldMapper extends FieldMapper {
             assert map.containsKey("items") : "HLL object does not contain 'items' key";
             assert map.containsKey("precision") : "HLL object does not contain 'precision' key";
             Object itemsObject = map.get("items");
-            List itemList = List.class.cast(itemsObject);
-            value = itemList.get(0);
+            if (itemsObject instanceof List) {
+                value = ((List)itemsObject).get(0);
+            }
         } else {
             // controlling the context is what allows us to access array and other values
             if (context.externalValueSet()) {

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -172,7 +172,7 @@ public class HLLFieldMapper extends FieldMapper {
             assert map.containsKey("items") : "HLL object does not contain 'items' key";
             assert map.containsKey("precision") : "HLL object does not contain 'precision' key";
             Object itemsObject = map.get("items");
-            List<String> itemList = (List)itemsObject;
+            List<String> itemList = (List<String>)itemsObject;
             value = itemList.get(0);
         } else {
             // controlling the context is what allows us to access array and other values

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -207,7 +207,8 @@ public class HLLFieldMapper extends FieldMapper {
             // HLL itself converted into a byte[]
             byte[] hllBytes = baos.toByteArray();
             int hllBytesLength = hllBytes.length;
-            assert hllBytesLength > 0 : "Encoded HLL had no bytes";
+            assert hllBytesLength != 0 : "Encoded HLL had no bytes";
+            // TODO: below assumption will break once we support multi-value here
             assert hllBytesLength == 7 : "Encoded HLL did not have 7 bytes";
             // FIXME: is it OK to use same BytesRef instance across two ops below?
             BytesRef hllBytesRef = new BytesRef(hllBytes);

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.index.mapper.hll;
 
-import com.carrotsearch.hppc.BitMixer;
-import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -202,11 +201,13 @@ public class HLLFieldMapper extends FieldMapper {
             }
             // HLL itself converted into a byte[]
             byte[] hllBytes = baos.toByteArray();
+            assert hllBytes.length > 0 : "Encoded HLL had no bytes";
             // FIXME: is it OK to use same BytesRef instance across two ops below?
             BytesRef hllBytesRef = new BytesRef(hllBytes);
 
             // stored as binary DocValues field
-            fields.add(new BinaryDocValuesField(fieldType().name(), hllBytesRef));
+            //fields.add(new BinaryDocValuesField(fieldType().name(), hllBytesRef));
+            fields.add(new SortedDocValuesField(fieldType().name(), hllBytesRef));
 
             // also stored in field storage (optionally, for reindexing)
             if (fieldType().stored()) {

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper.hll;
 
+import com.carrotsearch.hppc.BitMixer;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
@@ -186,8 +187,10 @@ public class HLLFieldMapper extends FieldMapper {
             final int rollupPrecision = 18;
             HyperLogLogPlusPlus counts = new HyperLogLogPlusPlus(rollupPrecision, BigArrays.NON_RECYCLING_INSTANCE, 0);
 
+            final long mixedHash = BitMixer.mix64(hash);
+
             // hashed bytes offered toHLL
-            counts.collect(0, hash);
+            counts.collect(0, mixedHash);
 
             // TODO: below are unused, for debugging only
             long cardinality = counts.cardinality(0);

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.metrics.cardinality.HyperLogLogPlus
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -173,6 +174,10 @@ public class HLLFieldMapper extends FieldMapper {
             assert map.containsKey("precision") : "HLL object does not contain 'precision' key";
             Object itemsObject = map.get("items");
             if (itemsObject instanceof List) {
+                // FIXME: right now, we're just passing one item out of the list because I'm still Java rusty
+                // The issue here is that List is a raw type, and I need it to be a List<String>. I forget how
+                // I can guarantee that. Meanwhile, down below, I'll need to change this from being a one-at-a-time
+                // process for building HLLs, to a for loop of some kind.
                 value = ((List)itemsObject).get(0);
             } else {
                 value = null;
@@ -185,6 +190,8 @@ public class HLLFieldMapper extends FieldMapper {
                 value = context.parser().textOrNull();
             }
         }
+
+        // FIXME: The below need sto become a for loop, which operates on a single-element list in the textOrNull case above
 
         if (value != null) {
             // value is turned into bytes

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -198,10 +198,13 @@ public class HLLFieldMapper extends FieldMapper {
                 counts.writeTo(0, osso);
             } catch (IOException e) {
                 // FIXME: when does this IOException actually happen?
+            } finally {
+                osso.close();
             }
             // HLL itself converted into a byte[]
             byte[] hllBytes = baos.toByteArray();
-            assert hllBytes.length > 0 : "Encoded HLL had no bytes";
+            int hllBytesLength = hllBytes.length;
+            assert hllBytesLength > 0 : "Encoded HLL had no bytes";
             // FIXME: is it OK to use same BytesRef instance across two ops below?
             BytesRef hllBytesRef = new BytesRef(hllBytes);
 

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -172,7 +172,7 @@ public class HLLFieldMapper extends FieldMapper {
             assert map.containsKey("items") : "HLL object does not contain 'items' key";
             assert map.containsKey("precision") : "HLL object does not contain 'precision' key";
             Object itemsObject = map.get("items");
-            List<String> itemList = (List<String>)itemsObject;
+            List itemList = List.class.cast(itemsObject);
             value = itemList.get(0);
         } else {
             // controlling the context is what allows us to access array and other values

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -174,6 +174,8 @@ public class HLLFieldMapper extends FieldMapper {
             Object itemsObject = map.get("items");
             if (itemsObject instanceof List) {
                 value = ((List)itemsObject).get(0);
+            } else {
+                value = null;
             }
         } else {
             // controlling the context is what allows us to access array and other values

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/index/mapper/hll/HLLFieldMapper.java
@@ -166,7 +166,7 @@ public class HLLFieldMapper extends FieldMapper {
         final Object value;
 
         // try to parse it as a map
-        XContentParser.Token token = context.parser().nextToken();
+        XContentParser.Token token = context.parser().currentToken();
         if (token == XContentParser.Token.START_OBJECT) {
             Map<String, Object> map = context.parser().map();
             assert map.containsKey("items") : "HLL object does not contain 'items' key";

--- a/plugins/mapper-hll/src/main/java/org/elasticsearch/plugin/mapper/MapperHLLPlugin.java
+++ b/plugins/mapper-hll/src/main/java/org/elasticsearch/plugin/mapper/MapperHLLPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.mapper;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.hll.HLLFieldMapper;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
+
+public class MapperHLLPlugin extends Plugin implements MapperPlugin {
+
+    @Override
+    public Map<String, Mapper.TypeParser> getMappers() {
+        return Collections.singletonMap(HLLFieldMapper.CONTENT_TYPE, new HLLFieldMapper.TypeParser());
+    }
+}

--- a/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/HLLFieldMapperTests.java
+++ b/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/HLLFieldMapperTests.java
@@ -156,4 +156,7 @@ public class HLLFieldMapperTests extends ESSingleNodeTestCase {
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
+
+    public void testArrayOfItems() throws Exception {
+    }
 }

--- a/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/HLLFieldMapperTests.java
+++ b/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/HLLFieldMapperTests.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.hll;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.indices.mapper.MapperRegistry;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class HLLFieldMapperTests extends ESSingleNodeTestCase {
+
+    MapperRegistry mapperRegistry;
+    IndexService indexService;
+    DocumentMapperParser parser;
+
+    @Before
+    public void setup() {
+        indexService = createIndex("test");
+        mapperRegistry = new MapperRegistry(
+                Collections.singletonMap(HLLFieldMapper.CONTENT_TYPE, new HLLFieldMapper.TypeParser()),
+                Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER);
+        Supplier<QueryShardContext> queryShardContext = () -> {
+            return indexService.newQueryShardContext(0, null, () -> { throw new UnsupportedOperationException(); }, null);
+        };
+        parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(), indexService.getIndexAnalyzers(),
+                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class);
+    }
+
+    public void testDefaults() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field")
+                    .field("type", "hll")
+                .endObject().endObject().endObject().endObject());
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        ParsedDocument parsedDoc = mapper.parse(SourceToParse.source("test", "type", "1", BytesReference.bytes(XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "value")
+                .endObject()),
+                XContentType.JSON));
+        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        assertNotNull(fields);
+        assertEquals(Arrays.toString(fields), 1, fields.length);
+        IndexableField field = fields[0];
+        assertEquals(IndexOptions.NONE, field.fieldType().indexOptions());
+        assertEquals(DocValuesType.BINARY, field.fieldType().docValuesType());
+    }
+
+    public void testDocValuesSettingNotAllowed() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field")
+                .field("type", "hll")
+                .field("doc_values", false)
+            .endObject().endObject().endObject().endObject());
+        try {
+            parser.parse("type", new CompressedXContent(mapping));
+            fail("expected a mapper parsing exception");
+        } catch (MapperParsingException e) {
+            assertTrue(e.getMessage().contains("Setting [doc_values] cannot be modified"));
+        }
+
+        // even setting to the default is not allowed, the setting is invalid
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field")
+                .field("type", "hll")
+                .field("doc_values", true)
+            .endObject().endObject().endObject().endObject());
+        try {
+            parser.parse("type", new CompressedXContent(mapping));
+            fail("expected a mapper parsing exception");
+        } catch (MapperParsingException e) {
+            assertTrue(e.getMessage().contains("Setting [doc_values] cannot be modified"));
+        }
+    }
+
+    public void testIndexSettingNotAllowed() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field")
+                .field("type", "hll")
+                .field("index", "not_analyzed")
+            .endObject().endObject().endObject().endObject());
+        try {
+            parser.parse("type", new CompressedXContent(mapping));
+            fail("expected a mapper parsing exception");
+        } catch (MapperParsingException e) {
+            assertTrue(e.getMessage().contains("Setting [index] cannot be modified"));
+        }
+
+        // even setting to the default is not allowed, the setting is invalid
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field")
+                .field("type", "hll")
+                .field("index", "no")
+            .endObject().endObject().endObject().endObject());
+        try {
+            parser.parse("type", new CompressedXContent(mapping));
+            fail("expected a mapper parsing exception");
+        } catch (MapperParsingException e) {
+            assertTrue(e.getMessage().contains("Setting [index] cannot be modified"));
+        }
+    }
+
+    public void testEmptyName() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("")
+            .field("type", "hll")
+            .endObject().endObject().endObject().endObject());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parser.parse("type", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("name cannot be empty string"));
+    }
+}

--- a/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/MapperHLLClientYamlTestSuiteIT.java
+++ b/plugins/mapper-hll/src/test/java/org/elasticsearch/index/mapper/hll/MapperHLLClientYamlTestSuiteIT.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.hll;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+public class MapperHLLClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    public MapperHLLClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return createParameters();
+    }
+}
+

--- a/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
+++ b/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
@@ -69,7 +69,7 @@
         index: test
         type: type1
         id: 5
-        body: { "foo": {"items": ["bar", "baz", "bam", "bar"], "precision": 18} }
+        body: { "foo": {"items": ["1", "2", "3", "4"], "precision": 18} }
 
   - do:
       indices.refresh: {}
@@ -78,4 +78,4 @@
       search:
         body: { "aggs": { "foo_count": { "cardinality": { "field": "foo" } } } }
 
-  - match: { aggregations.foo_count.value: 3 }
+  - match: { aggregations.foo_count.value: 7 }

--- a/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
+++ b/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
@@ -1,0 +1,65 @@
+# Integration tests for Mapper HLL components
+#
+
+---
+"Mapper HLL":
+
+    - do:
+        indices.create:
+            index: test
+            body:
+                mappings:
+                    type1: { "properties": { "foo": { "type": "text", "fields": { "hash": { "type": "hll" } } } } }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 0
+            body: { "foo": null }
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        search:
+            body: { "aggs": { "foo_count": { "cardinality": { "field": "foo.hash" } } } }
+
+    - match: { aggregations.foo_count.value: 0 }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 1
+            body: { "foo": "bar" }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 2
+            body: { "foo": "baz" }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 3
+            body: { "foo": "quux" }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 4
+            body: { "foo": "bar" }
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        search:
+            body: { "aggs": { "foo_count": { "cardinality": { "field": "foo.hash" } } } }
+
+    - match: { aggregations.foo_count.value: 0 }

--- a/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
+++ b/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
@@ -4,62 +4,62 @@
 ---
 "Mapper HLL":
 
-    - do:
-        indices.create:
-            index: test
-            body:
-                mappings:
-                    type1: { "properties": { "foo": { "type": "text", "fields": { "hash": { "type": "hll" } } } } }
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            type1: { "properties": { "foo": { "type": "hll" } } }
 
-    - do:
-        index:
-            index: test
-            type: type1
-            id: 0
-            body: { "foo": null }
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 0
+        body: { "foo": "bar" }
 
-    - do:
-        indices.refresh: {}
+  - do:
+      indices.refresh: {}
 
-    - do:
-        search:
-            body: { "aggs": { "foo_count": { "cardinality": { "field": "foo.hash" } } } }
+  - do:
+      search:
+        body: { "aggs": { "foo_count": { "cardinality": { "field": "foo" } } } }
 
-    - match: { aggregations.foo_count.value: 0 }
+  - match: { aggregations.foo_count.value: 1 }
 
-    - do:
-        index:
-            index: test
-            type: type1
-            id: 1
-            body: { "foo": "bar" }
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 1
+        body: { "foo": "bar" }
 
-    - do:
-        index:
-            index: test
-            type: type1
-            id: 2
-            body: { "foo": "baz" }
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 2
+        body: { "foo": "baz" }
 
-    - do:
-        index:
-            index: test
-            type: type1
-            id: 3
-            body: { "foo": "quux" }
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 3
+        body: { "foo": "bam" }
 
-    - do:
-        index:
-            index: test
-            type: type1
-            id: 4
-            body: { "foo": "bar" }
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 4
+        body: { "foo": "bar" }
 
-    - do:
-        indices.refresh: {}
+  - do:
+      indices.refresh: {}
 
-    - do:
-        search:
-            body: { "aggs": { "foo_count": { "cardinality": { "field": "foo.hash" } } } }
+  - do:
+      search:
+        body: { "aggs": { "foo_count": { "cardinality": { "field": "foo" } } } }
 
-    - match: { aggregations.foo_count.value: 0 }
+  - match: { aggregations.foo_count.value: 3 }

--- a/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
+++ b/plugins/mapper-hll/src/test/resources/rest-api-spec/test/mapper_hll/10_basic.yml
@@ -63,3 +63,19 @@
         body: { "aggs": { "foo_count": { "cardinality": { "field": "foo" } } } }
 
   - match: { aggregations.foo_count.value: 3 }
+
+  - do:
+      index:
+        index: test
+        type: type1
+        id: 5
+        body: { "foo": {"items": ["bar", "baz", "bam", "bar"], "precision": 18} }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "aggs": { "foo_count": { "cardinality": { "field": "foo" } } } }
+
+  - match: { aggregations.foo_count.value: 3 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -213,7 +213,10 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
-                counts.merge(0, rollup, 0);
+                long cardDeser = rollup.cardinality(0);
+                counts.merge(0, rollup, 1);
+                long cardCounts = counts.cardinality(0);
+                long cardRollup = rollup.cardinality(0);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -223,7 +223,6 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
                 long cardCounts1 = counts.cardinality(0);
                 long cardRollups1 = rollup.cardinality(0);
-                // TODO: why, on earth, is the value `0` expected everywhere for bucket?
                 counts.merge(0, rollup, 0);
                 long cardCounts2 = counts.cardinality(0);
                 long cardRollups2 = rollup.cardinality(0);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -90,12 +90,14 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
         // AM note: we simple had to try -- it can't be this easy?
         if (valuesSource instanceof ValuesSource.Bytes) {
+            // FIXME: Seems like this path isn't getting with `hll` field
             ValuesSource.Bytes source = (ValuesSource.Bytes) valuesSource;
             SortedBinaryDocValues rollupValues = source.bytesValues(ctx);
             return new RollupCollector(counts, rollupValues);
         }
 
         if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals) {
+            // FIXME: Oddly, this path *does* get with `hll` field as it is
             ValuesSource.Bytes.WithOrdinals source = (ValuesSource.Bytes.WithOrdinals) valuesSource;
             final SortedSetDocValues ordinalValues = source.ordinalsValues(ctx);
             final long maxOrd = ordinalValues.getValueCount();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -216,7 +216,6 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             // Each binary blob is in the SortedBinaryDocValues object, so we just advance along deserialize, and merge.
             if (rollups.advanceExact(doc)) {
                 BytesRef bytes = rollups.nextValue();
-                assert bytes.offset == 0 : "Decoded HLL did not have an offset of 0";
                 // assert bytes.length > 0 : "Decoded HLL had no bytes";
                 // Originally, we created the copy this way, but when I read more about
                 // what the BytesRef actually is, I realized it's totally wrong.
@@ -225,6 +224,8 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 // The right way to do it: use the alternative constructor of ByteArrayInputStream:
 
                 //byte[] hllBytes = BytesRef.deepCopyOf(bytes).bytes;
+                byte[] hllBytesCopy = BytesRef.deepCopyOf(bytes).bytes;
+                byte[] hllBytesRef = bytes.bytes;
                 ByteArrayInputStream bais = new ByteArrayInputStream(bytes.bytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -222,7 +222,8 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 // byte[] hllBytes = bytes.bytes;
                 // ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 // The right way to do it: use the alternative constructor of ByteArrayInputStream:
-                ByteArrayInputStream bais = new ByteArrayInputStream(bytes.bytes, bytes.offset, bytes.length);
+                byte[] hllBytes = BytesRef.deepCopyOf(bytes).bytes;
+                ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
                 long cardCounts1 = counts.cardinality(0);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -216,7 +216,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             // Each binary blob is in the SortedBinaryDocValues object, so we just advance along deserialize, and merge.
             if (rollups.advanceExact(doc)) {
                 BytesRef bytes = rollups.nextValue();
-                assert bytes.length > 0 : "Decoded HLL had no bytes";
+                // assert bytes.length > 0 : "Decoded HLL had no bytes";
                 // Originally, we created the copy this way, but when I read more about
                 // what the BytesRef actually is, I realized it's totally wrong.
                 // byte[] hllBytes = bytes.bytes;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -216,6 +216,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             // Each binary blob is in the SortedBinaryDocValues object, so we just advance along deserialize, and merge.
             if (rollups.advanceExact(doc)) {
                 BytesRef bytes = rollups.nextValue();
+                assert bytes.offset == 0 : "Decoded HLL did not have an offset of 0";
                 // assert bytes.length > 0 : "Decoded HLL had no bytes";
                 // Originally, we created the copy this way, but when I read more about
                 // what the BytesRef actually is, I realized it's totally wrong.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -208,7 +208,9 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             // deserialize, and merge. That easy?
             if (rollups.advanceExact(doc)) {
                 BytesRef bytes = rollups.nextValue();
-                ByteArrayInputStream bais = new ByteArrayInputStream(bytes.bytes);
+                byte[] hllBytes = bytes.bytes;
+                assert hllBytes.length > 0 : "Decoded HLL had no bytes";
+                ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
                 counts.merge(0, rollup, 0);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -222,8 +222,9 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 // byte[] hllBytes = bytes.bytes;
                 // ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 // The right way to do it: use the alternative constructor of ByteArrayInputStream:
-                byte[] hllBytes = BytesRef.deepCopyOf(bytes).bytes;
-                ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
+
+                //byte[] hllBytes = BytesRef.deepCopyOf(bytes).bytes;
+                ByteArrayInputStream bais = new ByteArrayInputStream(bytes.bytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
                 long cardCounts1 = counts.cardinality(0);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -216,10 +216,12 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
                 ByteArrayInputStream bais = new ByteArrayInputStream(hllBytes);
                 InputStreamStreamInput issi = new InputStreamStreamInput(bais);
                 HyperLogLogPlusPlus rollup = HyperLogLogPlusPlus.readFrom(issi, BigArrays.NON_RECYCLING_INSTANCE);
-                long cardDeser = rollup.cardinality(0);
-                counts.merge(0, rollup, 1);
-                long cardCounts = counts.cardinality(0);
-                long cardRollup = rollup.cardinality(0);
+                long cardCounts1 = counts.cardinality(0);
+                long cardRollups1 = rollup.cardinality(0);
+                counts.merge(0, rollup, 0);
+                long cardCounts2 = counts.cardinality(0);
+                long cardRollups2 = rollup.cardinality(0);
+                long maxBucket = rollup.maxBucket();
             }
         }
 


### PR DESCRIPTION
- [x] Write up basic spec of this project [in Notion][basic-spec]
- [x] Explore `HyperLogLogPlusPlus` class; read associated paper
- [x] Write new unit tests for serialization and deserialization of HLL
- [x] Record empirical results of those tests [in Notion][empirical-results]
- [x] Add a skeletal `mapper-hll` plugin based on the `mapper-murmur3` plugin
- [x] Hack around with making the serialized HLL go into binary doc values storage for the custom field type
- [x] Get remote debugging of ES and gradle integration tests with intellij working
- [x] Write a very basic end-to-end integration test for using the `hll` field and `cardinality` agg together
- [x] Hack around in `CardinalityAggregator` to make it pick up serialized HLL bytes
- [x] Make the initial integration test pass based on `HLLFieldMapper` and `CardinalityAggregator` changes!
- [x] Get answer on why `initialBucket` and `otherBucket` are always 0 right now
- [x] Work on making the `HLLFieldMapper` support arrays of values and a specified `precision` field; use the `GeoShape` field mapper for inspiration.
- [x] Explore how `XContentParser` works so that we can do streaming parsing of the `items` array.
- [ ] Look into this comment in `SortedDocValuesField`: "This value can be at most 32766 bytes long."
- [ ] Figure out if `BinaryDocValuesField` is what `HLLFieldMapper` should really be using, due to the above limit, but can't, perhaps due to the current ES `ValuesSource` implementation. (Is this what Zach was talking about?)
- [ ] Investigate whether the `ByteArrayOutputStream`, `ByteArrayInputStream` are the right options for HLL serialization/deserialization.
- [ ] See whether the stored field in the `HLLFieldMapper` is actually storing the `byte[]`, and also what option we could possibly have for displaying it (in searches) and using it for re-indexing operations.
- [ ] Explore whether there's a way to change what gets stored in `_source` for a given field, so that, e.g. we could store the serialized blob of the HLL in `_source` (note: we'd also need to support serialized HLLs in the `HLLFieldMapper` class) rather than being forced to store the raw items 
- [ ] :star: `BytesRef` stores whole bytes array, and it stores its own offset and length. Which means passing the underlying bytes array is not the right move. Might just be lucky in current impl.
- [ ] :star: Figure out how big an HLL Rollup can be to fit into 32766 bytes, just in case. (Somewhere near 10K.)
- [ ] :star: Make `HLLFieldMapper` support arrays of values via the streaming JSON parsing technique (tokens) rather than all-at-once parsing.
- [ ] :star: Rename `hll` field type to `hll-rollup`
- [ ] :star: Write up spec for abstracting the `CardinalityAggregator` changes into a new plugin with a new agg name, such as `hll-uniq`
- [ ] :star: Split hacked `CardinalityAggregator` code changes into that `hll-uniq` plugin
- [ ] :star: Build a real-world data set of URLs, timestamps, and UUIDs using BigQuery
- [ ] :star: Do a real world performance benchmark

[basic-spec]: https://www.notion.so/parsely/HyperLogLog-in-Elasticsearch-9d064b2cfeb947a6a8b9f1d727ea6392
[empirical-results]: https://www.notion.so/parsely/HLL-Rollup-initial-code-sketches-measurements-fcaeb2346b2144ee8575b5267ebac4a6